### PR TITLE
Changed the SAML response buffer xml to be decoded to a utf-8 string

### DIFF
--- a/lib/saml.js
+++ b/lib/saml.js
@@ -45,14 +45,14 @@ SAML.prototype.generateUniqueID = function () {
 
 /*SAML.prototype.generateInstant = function () {
   var date = new Date();
-  return date.getUTCFullYear() + '-' + ('0' + (date.getUTCMonth()+1)).slice(-2) + '-' + ('0' + date.getUTCDate()).slice(-2) + 'T' + ('0' + (date.getUTCHours()+2)).slice(-2) + ":" + ('0' + date.getUTCMinutes()).slice(-2) + ":" + ('0' + date.getUTCSeconds()).slice(-2) + "Z"; 
+  return date.getUTCFullYear() + '-' + ('0' + (date.getUTCMonth()+1)).slice(-2) + '-' + ('0' + date.getUTCDate()).slice(-2) + 'T' + ('0' + (date.getUTCHours()+2)).slice(-2) + ":" + ('0' + date.getUTCMinutes()).slice(-2) + ":" + ('0' + date.getUTCSeconds()).slice(-2) + "Z";
 };
 */
 
 //from old passport-saml plugin
 SAML.prototype.generateInstant = function () {
   return new Date().toISOString();
-}; 
+};
 
 SAML.prototype.signRequest = function (xml) {
   var signer = crypto.createSign('RSA-SHA1');
@@ -72,17 +72,17 @@ SAML.prototype.generateAuthorizeRequest = function (req) {
   }
 
   var request =
-   "<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" ID=\"" + id + "\" Version=\"2.0\" IssueInstant=\"" + instant + 
-   "\" ProtocolBinding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" AssertionConsumerServiceURL=\"" + callbackUrl + "\" Destination=\"" + 
+   "<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" ID=\"" + id + "\" Version=\"2.0\" IssueInstant=\"" + instant +
+   "\" ProtocolBinding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" AssertionConsumerServiceURL=\"" + callbackUrl + "\" Destination=\"" +
    this.options.entryPoint + "\">" +
     "<saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" + this.options.issuer + "</saml:Issuer>\n";
 
   if (this.options.identifierFormat) {
-    request += "<samlp:NameIDPolicy xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Format=\"" + this.options.identifierFormat + 
+    request += "<samlp:NameIDPolicy xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Format=\"" + this.options.identifierFormat +
     "\" AllowCreate=\"true\"></samlp:NameIDPolicy>\n";
   }
-   
- /* request += 
+
+ /* request +=
     "<samlp:RequestedAuthnContext xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Comparison=\"exact\">" +
     "<saml:AuthnContextClassRef xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext>\n" +
   "</samlp:AuthnRequest>";
@@ -96,9 +96,9 @@ SAML.prototype.generateLogoutRequest = function (req) {
   var id = "_" + this.generateUniqueID();
   var instant = this.generateInstant();
 
-  //samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" 
-  // ID="_135ad2fd-b275-4428-b5d6-3ac3361c3a7f" Version="2.0" Destination="https://idphost/adfs/ls/" 
-  //IssueInstant="2008-06-03T12:59:57Z"><saml:Issuer>myhost</saml:Issuer><NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" 
+  //samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+  // ID="_135ad2fd-b275-4428-b5d6-3ac3361c3a7f" Version="2.0" Destination="https://idphost/adfs/ls/"
+  //IssueInstant="2008-06-03T12:59:57Z"><saml:Issuer>myhost</saml:Issuer><NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
   //NameQualifier="https://idphost/adfs/ls/">myemail@mydomain.com</NameID<samlp:SessionIndex>_0628125f-7f95-42cc-ad8e-fde86ae90bbe
   //</samlp:SessionIndex></samlp:LogoutRequest>
 
@@ -124,9 +124,9 @@ SAML.prototype.requestToUrl = function (request, operation, callback) {
     if (operation === 'logout') {
       if (self.options.logoutUrl) {
         target = self.options.logoutUrl + '?';
-      } 
+      }
     }
- 
+
     var samlRequest = {
       SAMLRequest: base64
     };
@@ -143,7 +143,7 @@ SAML.prototype.requestToUrl = function (request, operation, callback) {
 
 SAML.prototype.getAuthorizeUrl = function (req, callback) {
   var request = this.generateAuthorizeRequest(req);
-  
+
   this.requestToUrl(request, 'authorize', callback);
 };
 
@@ -161,27 +161,27 @@ SAML.prototype.certToPEM = function (cert) {
 };
 
 SAML.prototype.checkSAMLStatus = function (xmlDomDoc) {
-	var status = {StatusCodeValue:null, StatusMessage:null, StatusDetail:null}	
-	
+	var status = {StatusCodeValue:null, StatusMessage:null, StatusDetail:null}
+
 	var statusCodeValueNode = xmlCrypto.xpath(xmlDomDoc, "//*[local-name(.)='StatusCode']")[0];
 	if(statusCodeValueNode)
 	{
 		status.StatusCodeValue  = statusCodeValueNode.getAttribute('Value');
 	}
-	
+
 	var statusMessageNode = xmlCrypto.xpath(xmlDomDoc, "//*[local-name(.)='StatusMessage']")[0];
 	if(statusMessageNode)
 	{
 		status.StatusMessage  = statusMessageNode.childNodes[0].nodeValue;
 	}
-	
-	var statusDetailNode = xmlCrypto.xpath(xmlDomDoc, "//*[local-name(.)='StatusDetail']/*[local-name(.)='Cause']")[0];	
+
+	var statusDetailNode = xmlCrypto.xpath(xmlDomDoc, "//*[local-name(.)='StatusDetail']/*[local-name(.)='Cause']")[0];
 	if(statusDetailNode)
 	{
 		status.StatusDetail  = statusDetailNode.childNodes[0].nodeValue;
 	}
 	//status.StatusMessage = xmlCrypto.xpath(xmlDomDoc, "//*[local-name(.)='StatusMessage']")[0].childNodes[0].nodeValue;
-	//status.StatusDetail = xmlCrypto.xpath(xmlDomDoc, "//*[local-name(.)='StatusDetail']/*[local-name(.)='Cause']")[0].childNodes[0].nodeValue;	
+	//status.StatusDetail = xmlCrypto.xpath(xmlDomDoc, "//*[local-name(.)='StatusDetail']/*[local-name(.)='Cause']")[0].childNodes[0].nodeValue;
 	return status;
 };
 
@@ -189,15 +189,15 @@ SAML.prototype.decryptSAMLAssertion = function (xmlDomDoc, privateCert) {
 	var encryptedDataNode  = xmlCrypto.xpath(xmlDomDoc, "//*[local-name(.)='EncryptedData' and namespace-uri(.)='http://www.w3.org/2001/04/xmlenc#']")[0];
 	var encryptedData = encryptedDataNode.toString();
 	//console.log(encryptedData);
-	var decryptOptions = {    key: privateCert	};	
+	var decryptOptions = {    key: privateCert	};
 	var resultObj = decryptSAML(encryptedData,decryptOptions);
-	if(resultObj.result) 
+	if(resultObj.result)
 	{
 		return resultObj.result;
 	}
 	else
 	{
-		return resultObj.err;	
+		return resultObj.err;
 	}
 };
 
@@ -223,30 +223,30 @@ SAML.prototype.getElement = function (parentElement, elementName) {
     return parentElement['saml:' + elementName];
   } else if (parentElement['samlp:'+elementName]) {
     return parentElement['samlp:'+elementName];
-  } 
+  }
   return parentElement[elementName];
 }
 
 SAML.prototype.validateResponse = function (samlResponse, callback) {
   var self = this;
-  var xml = new Buffer(samlResponse, 'base64').toString('ascii');
-  
-  var samlAssertion = null;  
+  var xml = new Buffer(samlResponse, 'base64').toString();
+
+  var samlAssertion = null;
 	// Verify signature on the response
 	if (self.options.cert && !self.validateSignature(xml, self.options.cert)) {
 	  return callback(new Error('Invalid signature'), null, false);
 	}
-	
+
 	var xmlDomDoc = new xmldom.DOMParser().parseFromString(xml);
 	//Check Status code in the SAML Response
 	var statusObj = self.checkSAMLStatus(xmlDomDoc);
 	if(statusObj.StatusCodeValue != "urn:oasis:names:tc:SAML:2.0:status:Success")
 		return callback(new Error('SAML Error Response:\nStatusCodeValue = '+ statusObj.StatusCodeValue + '\nStatusMessage = ' + statusObj.StatusMessage + '\nStatusDetail = ' + statusObj.StatusDetail + '\n'), null, false);
-	
-	 // Decrypt and Retrieve SAML Assertion 
+
+	 // Decrypt and Retrieve SAML Assertion
 	if (self.options.encryptedSAML &&  self.options.privateCert)
 	{
-		samlAssertion = self.decryptSAMLAssertion(xmlDomDoc, self.options.privateCert); 
+		samlAssertion = self.decryptSAMLAssertion(xmlDomDoc, self.options.privateCert);
 		if (!samlAssertion){
 	  		return callback(new Error('Decryption Failed'), null, false);
 		}
@@ -262,24 +262,24 @@ SAML.prototype.validateResponse = function (samlResponse, callback) {
 			return callback(new Error('Invalid signature'), null, false);
 		}
 	}
-	else //Retrieve SAML Assertion 
+	else //Retrieve SAML Assertion
 	{
 		samlAssertionNode = xmlCrypto.xpath(xmlDomDoc, "//*[local-name(.)='Assertion']")[0];
 		if (samlAssertionNode)
-		{	
+		{
 			samlAssertion = samlAssertionNode.toString();
 		}
 		else
 		{
 			return callback(new Error('Missing Assertion'), null, false);
 		}
-	}		
-	
+	}
+
 	var parser = new xml2js.Parser({explicitRoot:true});
- 	parser.parseString(samlAssertion, function (err, doc) {   
-	
+ 	parser.parseString(samlAssertion, function (err, doc) {
+
 	var assertion = self.getElement(doc, 'Assertion');
-	
+
     if (assertion) {
       /*
       if (!assertion) {
@@ -322,7 +322,7 @@ SAML.prototype.validateResponse = function (samlResponse, callback) {
           }
         });
       }
-        
+
 
       if (!profile.mail && profile['urn:oid:0.9.2342.19200300.100.1.3']) {
         // See http://www.incommonfederation.org/attributesummary.html for definition of attribute OIDs


### PR DESCRIPTION
Changed the code type from ascii to utf-8 when receiving the SAML response. This will fix the issue when the IdP returns a SAML response with utf-8 encoded data values and the contained signature is based off that encoding. It will prevent signature validation issues later down the line.
