### PR TITLE
Added checks for expired assertion

### DIFF
--- a/lib/saml.js
+++ b/lib/saml.js
@@ -305,6 +305,11 @@ SAML.prototype.validateResponse = function (samlResponse, callback) {
       }
 	  */
 
+      var expires = new Date(self.getElement(assertion, 'Conditions')[0]['$'].NotOnOrAfter);
+      if (expires < Date.now()) {
+        return callback(new Error('Expired SAML assertion'), null, false);
+      }
+
       profile = {};
       var issuer = self.getElement(assertion, 'Issuer');
       if (issuer) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-saml-encrypted",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A Passport strategy for handling encrypted SAML authentication responses",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Current versions don't validate that the SAML assertion conditions for NotOnOrAfter are met. Without checking this parameter, apps are vulnerable to replay attacks where the user can save the SAML assertion and post it back to the app in the future without having to log in. 