### PR TITLE
Update the saml id length to match the spec

### DIFF
--- a/lib/saml.js
+++ b/lib/saml.js
@@ -37,7 +37,7 @@ SAML.prototype.initialize = function (options) {
 SAML.prototype.generateUniqueID = function () {
   var chars = "abcdef0123456789";
   var uniqueID = "";
-  var idLength = (Math.random()*8) + 32
+  var idLength = (Math.floor(Math.random() * 9)) + 32
   for (var i = 0; i < idLength; i++) {
     uniqueID += chars.substr(Math.floor((Math.random()*15)), 1);
   }

--- a/lib/saml.js
+++ b/lib/saml.js
@@ -37,7 +37,8 @@ SAML.prototype.initialize = function (options) {
 SAML.prototype.generateUniqueID = function () {
   var chars = "abcdef0123456789";
   var uniqueID = "";
-  for (var i = 0; i < 20; i++) {
+  var idLength = (Math.random()*8) + 32
+  for (var i = 0; i < idLength; i++) {
     uniqueID += chars.substr(Math.floor((Math.random()*15)), 1);
   }
   return uniqueID;


### PR DESCRIPTION
Update generateUniqueID to conform to the spec length. Spec here https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
> 1.3.4 ID and ID Reference Values
> This requirement MAY be met by encoding a randomly chosen value between 128 and 160 bits in length.