### PR TITLE
Add code comments to for internal documentation for validateSignature()

### DIFF
--- a/lib/saml.js
+++ b/lib/saml.js
@@ -220,6 +220,10 @@ SAML.prototype.decryptSAMLAssertion = function (xmlDomDoc, privateCert) {
 	}
 };
 
+// Validates the given `xml` using `cert` and returns true if successsful
+// Used for validating both the top level SAML response as well as assertions
+// We always expect a signature to be found at the top level of the XML passed in,
+// using the first signature and ignoring others.
 SAML.prototype.validateSignature = function (xml, cert) {
   var self = this;
   var doc = new xmldom.DOMParser().parseFromString(xml);


### PR DESCRIPTION
I thinks it's significant to note that:

  * This is used both for top-level XML and assertions
  * Where in the XML we expect to find the signature (for this who don't immediately recognize Xpath syntax)
  * What happens in case there happen to be multiple signatures
  * What the return value is (which is obscured because control flow is passed to `checkSignature`.