### PR TITLE
checkSAMLStatus method not passed any callback

### DIFF
--- a/lib/saml.js
+++ b/lib/saml.js
@@ -179,7 +179,7 @@ SAML.prototype.certToPEM = function (cert) {
   return cert;
 };
 
-SAML.prototype.checkSAMLStatus = function (xmlDomDoc) {
+SAML.prototype.checkSAMLStatus = function (xmlDomDoc, callback) {
 	var status = {StatusCodeValue:null, StatusMessage:null, StatusDetail:null}, statusCodeValueNode = null, statusMessageNode = null, statusDetailNode = null;
 
 	try{
@@ -308,7 +308,7 @@ SAML.prototype.validateResponse = function (samlResponse, callback) {
 
 	var xmlDomDoc = new xmldom.DOMParser().parseFromString(xml);
 	//Check Status code in the SAML Response
-	var statusObj = self.checkSAMLStatus(xmlDomDoc);
+	var statusObj = self.checkSAMLStatus(xmlDomDoc, callback);
 	if(statusObj.StatusCodeValue != "urn:oasis:names:tc:SAML:2.0:status:Success")
 		return callback(new Error('SAML Error Response:\nStatusCodeValue = '+ statusObj.StatusCodeValue + '\nStatusMessage = ' + statusObj.StatusMessage + '\nStatusDetail = ' + statusObj.StatusDetail + '\n'), null, false);
 


### PR DESCRIPTION
checkSAMLStatus method is not passed any callback, causing RefrenceError being thrown.