### PR TITLE
updating xml-encryption dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "xml2js": "~0.4.1",
     "xml-crypto": "0.8.4",
     "xmldom": "~0.1.19",
-    "xml-encryption": "~0.7.2",
+    "xml-encryption": "~0.11.2",
     "xpath": "0.0.5",
     "passport": "^0.3.x"
   }


### PR DESCRIPTION
xml-encryption paypal is bringing in ejs@0.8.8 which has a security vulnerability.
https://nvd.nist.gov/vuln/detail/CVE-2017-1000188

xml-encryption@0.11.2 updates ejs dependnecy to > 2.5.5 which fixes the security vulnerability.
As far as I can tell, there are no breaking changes between xml-encryption 0.7.2 and 0.11.2